### PR TITLE
Fix hass template error:

### DIFF
--- a/k8s/prod/hass/files/automations.yaml
+++ b/k8s/prod/hass/files/automations.yaml
@@ -198,7 +198,7 @@
       below: 70 # door gets weird after 70%
     - platform: template
       value_template: >
-        {{ state_attr('sensor.dog_food_battery', 'battery') | float < 20 }}
+        {{ state_attr('sensor.dog_food_battery', 'battery') | float(0) < 20 }}
     - platform: state
       entity_id:
         - binary_sensor.keypad_battery


### PR DESCRIPTION
  homeassistant.exceptions.TemplateError: ValueError: Template error: float got invalid input 'None' when rendering template '{{ state_attr('sensor.dog_food_battery', 'battery') | float < 20 }}' but no default was specified