### PR TITLE
Hass: only fire when dog food battery is between 10 and 30

### DIFF
--- a/k8s/prod/hass/files/automations.yaml
+++ b/k8s/prod/hass/files/automations.yaml
@@ -198,7 +198,7 @@
       below: 70 # door gets weird after 70%
     - platform: template
       value_template: >
-        {{ state_attr('sensor.dog_food_battery', 'battery') | float(0) < 20 }}
+        {{ 10 < state_attr('sensor.dog_food_battery', 'battery') | float(0) < 30 }}
     - platform: state
       entity_id:
         - binary_sensor.keypad_battery


### PR DESCRIPTION
  Adding a default value of 0 causes this to fire when its unavailable,
  which is often because it is not an always on device